### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/174/401/421174401.geojson
+++ b/data/421/174/401/421174401.geojson
@@ -679,6 +679,9 @@
     ],
     "wof:country":"KE",
     "wof:created":1459009031,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"adab6993967ef2bce2b5ce5b5a8b562a",
     "wof:hierarchy":[
         {
@@ -690,7 +693,7 @@
         }
     ],
     "wof:id":421174401,
-    "wof:lastmodified":1566727048,
+    "wof:lastmodified":1582344730,
     "wof:name":"Nairobi",
     "wof:parent_id":1091912313,
     "wof:placetype":"locality",

--- a/data/421/189/991/421189991.geojson
+++ b/data/421/189/991/421189991.geojson
@@ -422,6 +422,9 @@
     },
     "wof:country":"KE",
     "wof:created":1459009643,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11c5eccd5fa4f47aa9a7df60c11cfae6",
     "wof:hierarchy":[
         {
@@ -433,7 +436,7 @@
         }
     ],
     "wof:id":421189991,
-    "wof:lastmodified":1566727048,
+    "wof:lastmodified":1582344730,
     "wof:name":"Old Mombasa",
     "wof:parent_id":1091912207,
     "wof:placetype":"locality",

--- a/data/421/198/627/421198627.geojson
+++ b/data/421/198/627/421198627.geojson
@@ -175,6 +175,9 @@
     },
     "wof:country":"KE",
     "wof:created":1459009954,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"1bc996eb49e5ebd63f9a4241053985a6",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":421198627,
-    "wof:lastmodified":1561777174,
+    "wof:lastmodified":1582344730,
     "wof:name":"Kendu Bay",
     "wof:parent_id":890427529,
     "wof:placetype":"locality",

--- a/data/856/323/29/85632329.geojson
+++ b/data/856/323/29/85632329.geojson
@@ -997,6 +997,11 @@
     },
     "wof:country":"KE",
     "wof:country_alpha3":"KEN",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"cfebb9b97be04ab5e623266054647092",
     "wof:hierarchy":[
         {
@@ -1013,7 +1018,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Kenya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/729/43/85672943.geojson
+++ b/data/856/729/43/85672943.geojson
@@ -355,6 +355,9 @@
         "wd:id":"Q93352"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed51a32a3284bdcc60ee70db0f730cc8",
     "wof:hierarchy":[
         {
@@ -372,7 +375,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726979,
+    "wof:lastmodified":1582344726,
     "wof:name":"Coast",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/47/85672947.geojson
+++ b/data/856/729/47/85672947.geojson
@@ -254,6 +254,9 @@
         "wk:page":"Central Province (Kenya)"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2471f7523575e11d59fc108033f89334",
     "wof:hierarchy":[
         {
@@ -271,7 +274,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726980,
+    "wof:lastmodified":1582344727,
     "wof:name":"Central",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/51/85672951.geojson
+++ b/data/856/729/51/85672951.geojson
@@ -239,6 +239,9 @@
         421174401
     ],
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"adab6993967ef2bce2b5ce5b5a8b562a",
     "wof:hierarchy":[
         {
@@ -256,7 +259,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726979,
+    "wof:lastmodified":1582344726,
     "wof:name":"Nairobi",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/55/85672955.geojson
+++ b/data/856/729/55/85672955.geojson
@@ -251,6 +251,9 @@
         "wk:page":"Nyanza Province"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c86d6fbfc99b45dc727d6ca8dc301621",
     "wof:hierarchy":[
         {
@@ -268,7 +271,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726979,
+    "wof:lastmodified":1582344726,
     "wof:name":"Nyanza",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/59/85672959.geojson
+++ b/data/856/729/59/85672959.geojson
@@ -250,6 +250,9 @@
         "wk:page":"Eastern Province (Kenya)"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86f7c1a3eb9987c55bba9900df58d4e2",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726978,
+    "wof:lastmodified":1582344725,
     "wof:name":"Eastern",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/63/85672963.geojson
+++ b/data/856/729/63/85672963.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Rift Valley Province"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"54b2e5b85197942bfc85aae3e875e1fb",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726979,
+    "wof:lastmodified":1582344726,
     "wof:name":"Rift Valley",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/67/85672967.geojson
+++ b/data/856/729/67/85672967.geojson
@@ -248,6 +248,9 @@
         "wk:page":"Western Province (Kenya)"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f24c8757c2ec58772b1e0123dea11f6a",
     "wof:hierarchy":[
         {
@@ -265,7 +268,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726979,
+    "wof:lastmodified":1582344726,
     "wof:name":"Western",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/69/85672969.geojson
+++ b/data/856/729/69/85672969.geojson
@@ -210,6 +210,9 @@
         "wk:page":"North Eastern Province (Kenya)"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b5ba85df81a09574f51393ca78e5978",
     "wof:hierarchy":[
         {
@@ -227,7 +230,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1566726978,
+    "wof:lastmodified":1582344726,
     "wof:name":"North-Eastern",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/857/719/13/85771913.geojson
+++ b/data/857/719/13/85771913.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1064130
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6bc0894a6a13485d08a8c3c2209e9c3f",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Chiromo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/19/85771919.geojson
+++ b/data/857/719/19/85771919.geojson
@@ -77,6 +77,9 @@
         "wk:page":"Doonholm"
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c1396df9686726baab94fb44dcff309",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379373,
+    "wof:lastmodified":1582344724,
     "wof:name":"Doonholm",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/23/85771923.geojson
+++ b/data/857/719/23/85771923.geojson
@@ -79,6 +79,9 @@
         "qs:id":7552
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"39beef6741d86152b85f405a03c23418",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379373,
+    "wof:lastmodified":1582344724,
     "wof:name":"Kileleshwa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/25/85771925.geojson
+++ b/data/857/719/25/85771925.geojson
@@ -74,6 +74,9 @@
         "qs:id":221253
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5cd975b49979f00036415c8f044f861b",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379373,
+    "wof:lastmodified":1582344724,
     "wof:name":"Mbotela",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/29/85771929.geojson
+++ b/data/857/719/29/85771929.geojson
@@ -134,6 +134,9 @@
         "qs_pg:id":275493
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1404e6e5b7699c19466a762bff1db11e",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Moi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/33/85771933.geojson
+++ b/data/857/719/33/85771933.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1028505
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e671d12298ce644e95b5dbdbc7d28826",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Muthaiga",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/39/85771939.geojson
+++ b/data/857/719/39/85771939.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":189193
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53a3ebf50023180383441ce261ec70cb",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Nairobi Hill",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/43/85771943.geojson
+++ b/data/857/719/43/85771943.geojson
@@ -74,6 +74,9 @@
         "qs:id":894362
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"338b3a6abe5072f3225d91e1ff8f7f7a",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379373,
+    "wof:lastmodified":1582344724,
     "wof:name":"Nairobi Industrial Area",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/45/85771945.geojson
+++ b/data/857/719/45/85771945.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":247159
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82b05cb284b6c5a43a0dbdc303816b52",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Nairobi South",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/49/85771949.geojson
+++ b/data/857/719/49/85771949.geojson
@@ -74,6 +74,9 @@
         "qs:id":1081060
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17d8e35daffb67f52bc635f4ff00590a",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379373,
+    "wof:lastmodified":1582344724,
     "wof:name":"Pangani",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/55/85771955.geojson
+++ b/data/857/719/55/85771955.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":317040
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62b76f3dc18c4aa626f0ee68b7969b8f",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Shauri Moyo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/719/59/85771959.geojson
+++ b/data/857/719/59/85771959.geojson
@@ -119,6 +119,9 @@
         "qs_pg:id":219417
     },
     "wof:country":"KE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3ea39878a58c822adcf69c0850e633d",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566726977,
+    "wof:lastmodified":1582344724,
     "wof:name":"Spring Valley",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/427/529/890427529.geojson
+++ b/data/890/427/529/890427529.geojson
@@ -95,6 +95,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469051700,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"915ab44dd5b7d6ca2b68473d5d095a2a",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":890427529,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344730,
     "wof:name":"Rachuonyo",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/890/431/213/890431213.geojson
+++ b/data/890/431/213/890431213.geojson
@@ -316,6 +316,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469051882,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"217c93873295aa512de0bbe400c04c13",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
         }
     ],
     "wof:id":890431213,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344730,
     "wof:name":"Malindi",
     "wof:parent_id":1091911877,
     "wof:placetype":"locality",

--- a/data/890/431/355/890431355.geojson
+++ b/data/890/431/355/890431355.geojson
@@ -328,6 +328,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469051887,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cc4c864318ec943060e9525f44e90977",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
         }
     ],
     "wof:id":890431355,
-    "wof:lastmodified":1566727052,
+    "wof:lastmodified":1582344730,
     "wof:name":"Kisumu",
     "wof:parent_id":1091911657,
     "wof:placetype":"locality",

--- a/data/890/431/357/890431357.geojson
+++ b/data/890/431/357/890431357.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469051887,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bc8084073151dca1918551861bfb63c",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890431357,
-    "wof:lastmodified":1566727052,
+    "wof:lastmodified":1582344730,
     "wof:name":"Kirinyaga",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/890/433/257/890433257.geojson
+++ b/data/890/433/257/890433257.geojson
@@ -321,6 +321,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469051972,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"904675ff8ce097245119ea906bb82651",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         }
     ],
     "wof:id":890433257,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344731,
     "wof:name":"Eldoret",
     "wof:parent_id":1091912837,
     "wof:placetype":"locality",

--- a/data/890/437/763/890437763.geojson
+++ b/data/890/437/763/890437763.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469052165,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f2e523d09ae517f2f289d9a1ab6d5a7",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":890437763,
-    "wof:lastmodified":1566727052,
+    "wof:lastmodified":1582344730,
     "wof:name":"Nyandarua",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/890/440/097/890440097.geojson
+++ b/data/890/440/097/890440097.geojson
@@ -306,6 +306,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469052262,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f901bb083beff8580b49e7d1ecb9b41b",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
         }
     ],
     "wof:id":890440097,
-    "wof:lastmodified":1566727052,
+    "wof:lastmodified":1582344730,
     "wof:name":"Machakos",
     "wof:parent_id":1091911873,
     "wof:placetype":"locality",

--- a/data/890/442/857/890442857.geojson
+++ b/data/890/442/857/890442857.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469052383,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"874b239efbcad0949ffb2dcd0ae1e818",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890442857,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344730,
     "wof:name":"Taita Taveta",
     "wof:parent_id":85672943,
     "wof:placetype":"county",

--- a/data/890/442/923/890442923.geojson
+++ b/data/890/442/923/890442923.geojson
@@ -287,6 +287,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469052388,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c82cfbcde94451797b057a11467e39cc",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         }
     ],
     "wof:id":890442923,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344731,
     "wof:name":"Meru",
     "wof:parent_id":1091912097,
     "wof:placetype":"locality",

--- a/data/890/443/511/890443511.geojson
+++ b/data/890/443/511/890443511.geojson
@@ -280,6 +280,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469052426,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6143846ef5857fac05bd48c37c14d89f",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":890443511,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344730,
     "wof:name":"Kisii",
     "wof:parent_id":1091911163,
     "wof:placetype":"locality",

--- a/data/890/443/513/890443513.geojson
+++ b/data/890/443/513/890443513.geojson
@@ -204,6 +204,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469052426,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"963cc16c7bff0927be1606cc5b6eb2f4",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
         }
     ],
     "wof:id":890443513,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344730,
     "wof:name":"Kilifi",
     "wof:parent_id":1091911611,
     "wof:placetype":"locality",

--- a/data/890/443/515/890443515.geojson
+++ b/data/890/443/515/890443515.geojson
@@ -270,6 +270,9 @@
     },
     "wof:country":"KE",
     "wof:created":1469052426,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3fa2f6f1a0ce27974002b4bdf87e63f2",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
         }
     ],
     "wof:id":890443515,
-    "wof:lastmodified":1566727053,
+    "wof:lastmodified":1582344730,
     "wof:name":"Kericho",
     "wof:parent_id":1091911533,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.