### PR TITLE
ke concordances, placetype local, and more

### DIFF
--- a/data/109/191/085/9/1091910859.geojson
+++ b/data/109/191/085/9/1091910859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.702223,
-    "geom:area_square_m":8682099073.601912,
+    "geom:area_square_m":8682098455.100311,
     "geom:bbox":"35.597632,0.183432,36.491747,1.642894",
     "geom:latitude":0.822164,
     "geom:longitude":35.96802,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892583,
-    "wof:geomhash":"3dd3d452340c6592bdae137703db355e",
+    "wof:geomhash":"4c01288d68c32e0ad1ad48177c86c8ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091910859,
-    "wof:lastmodified":1627522275,
+    "wof:lastmodified":1695886744,
     "wof:name":"Baringo",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/090/7/1091910907.geojson
+++ b/data/109/191/090/7/1091910907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116465,
-    "geom:area_square_m":1439959091.710756,
+    "geom:area_square_m":1439959079.473178,
     "geom:bbox":"35.014908,-1.03538,35.54507,-0.64634",
     "geom:latitude":-0.827247,
     "geom:longitude":35.274165,
@@ -85,9 +85,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892584,
-    "wof:geomhash":"115195af7ed35b4f6711433e2821c862",
+    "wof:geomhash":"cc89606c784faf97adb6e9ac57536f59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1091910907,
-    "wof:lastmodified":1627522275,
+    "wof:lastmodified":1695886744,
     "wof:name":"Bomet",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/095/3/1091910953.geojson
+++ b/data/109/191/095/3/1091910953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149796,
-    "geom:area_square_m":1852243682.29914,
+    "geom:area_square_m":1852243932.365993,
     "geom:bbox":"33.954882,-0.424301,34.480849,0.044802",
     "geom:latitude":-0.181928,
     "geom:longitude":34.21609,
@@ -121,9 +121,10 @@
         "hasc:id":"KE.NY.SI",
         "wd:id":"Q2252471"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892585,
-    "wof:geomhash":"a3abcc64017cb0124b6b1b38c827a89b",
+    "wof:geomhash":"75353aed854effeaf563217738d849f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1091910953,
-    "wof:lastmodified":1636500534,
+    "wof:lastmodified":1695886759,
     "wof:name":"Bondo",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/098/5/1091910985.geojson
+++ b/data/109/191/098/5/1091910985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.167786,
-    "geom:area_square_m":2074557043.518855,
+    "geom:area_square_m":2074557224.585886,
     "geom:bbox":"34.367756,0.435061,35.066062,0.886987",
     "geom:latitude":0.669484,
     "geom:longitude":34.659076,
@@ -142,9 +142,10 @@
     "wof:concordances":{
         "hasc:id":"KE.WE.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892587,
-    "wof:geomhash":"48b1e9c1f177c9cdc63eda732d20fb6b",
+    "wof:geomhash":"0e9045d47b458d9578ddc7bb4b7d1ffc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1091910985,
-    "wof:lastmodified":1636500532,
+    "wof:lastmodified":1695886758,
     "wof:name":"Bungoma",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/103/5/1091911035.geojson
+++ b/data/109/191/103/5/1091911035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113451,
-    "geom:area_square_m":1402775745.310619,
+    "geom:area_square_m":1402775593.564362,
     "geom:bbox":"35.052686,-0.722385,35.587021,-0.365249",
     "geom:latitude":-0.549085,
     "geom:longitude":35.298104,
@@ -76,9 +76,10 @@
         "hasc:id":"KE.RV.BO",
         "wd:id":"Q1010616"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892588,
-    "wof:geomhash":"d33350fa6c80dad96e35ddef9b3be71c",
+    "wof:geomhash":"8cc5655b78173c54805f3332307da1ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091911035,
-    "wof:lastmodified":1627522275,
+    "wof:lastmodified":1695886744,
     "wof:name":"Buret",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/107/5/1091911075.geojson
+++ b/data/109/191/107/5/1091911075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102274,
-    "geom:area_square_m":1264617757.620862,
+    "geom:area_square_m":1264617546.156411,
     "geom:bbox":"33.909829,-0.038522,34.414971,0.608333",
     "geom:latitude":0.29011,
     "geom:longitude":34.15597,
@@ -115,9 +115,10 @@
     "wof:concordances":{
         "hasc:id":"KE.WE.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892590,
-    "wof:geomhash":"b17efaf1043af79f02b59dc16ec17919",
+    "wof:geomhash":"685d26c349889fc4c9c154863da96264",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091911075,
-    "wof:lastmodified":1636500533,
+    "wof:lastmodified":1695886758,
     "wof:name":"Busia",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/112/1/1091911121.geojson
+++ b/data/109/191/112/1/1091911121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075729,
-    "geom:area_square_m":936385878.134616,
+    "geom:area_square_m":936386578.235086,
     "geom:bbox":"34.346511,0.095727,34.681481,0.48025",
     "geom:latitude":0.292751,
     "geom:longitude":34.509737,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"KE.WE.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892591,
-    "wof:geomhash":"3e72b3027a98d600e59f6fcb4ed83617",
+    "wof:geomhash":"5e7d4921c5e9523737ba8c63c5b0ae8e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091911121,
-    "wof:lastmodified":1627522275,
+    "wof:lastmodified":1695886744,
     "wof:name":"Butere/mumias",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/116/3/1091911163.geojson
+++ b/data/109/191/116/3/1091911163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05286,
-    "geom:area_square_m":653575093.568549,
+    "geom:area_square_m":653575257.160731,
     "geom:bbox":"34.639285,-0.911212,35.016055,-0.497328",
     "geom:latitude":-0.696215,
     "geom:longitude":34.817561,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892593,
-    "wof:geomhash":"f2e6f95f554f7575dc764a663126bf96",
+    "wof:geomhash":"99029c26c194a181c2866bd565a1ff1b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091911163,
-    "wof:lastmodified":1627522275,
+    "wof:lastmodified":1695886745,
     "wof:name":"Central Kisii",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/120/7/1091911207.geojson
+++ b/data/109/191/120/7/1091911207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060444,
-    "geom:area_square_m":747382101.408237,
+    "geom:area_square_m":747382570.604031,
     "geom:bbox":"37.313417,-0.586682,37.709172,-0.158824",
     "geom:latitude":-0.406113,
     "geom:longitude":37.503795,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.EB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892594,
-    "wof:geomhash":"ffb2b346ffe529c9d3cc033d7e147478",
+    "wof:geomhash":"000bb7cbab7ba9738bd5b0d2462486b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1091911207,
-    "wof:lastmodified":1636500532,
+    "wof:lastmodified":1695886758,
     "wof:name":"Embu",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/124/9/1091911249.geojson
+++ b/data/109/191/124/9/1091911249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.629588,
-    "geom:area_square_m":44875511150.147301,
+    "geom:area_square_m":44875511444.809731,
     "geom:bbox":"38.670505,-2.032075,41.559176,0.995236",
     "geom:latitude":-0.486039,
     "geom:longitude":40.182566,
@@ -169,9 +169,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NE.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892596,
-    "wof:geomhash":"4aab725d6ca83dcf6aae5b46e481c00d",
+    "wof:geomhash":"b87c074e570002b2f81ad785af3d3b56",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":1091911249,
-    "wof:lastmodified":1636500534,
+    "wof:lastmodified":1695886759,
     "wof:name":"Garissa",
     "wof:parent_id":85672969,
     "wof:placetype":"county",

--- a/data/109/191/127/7/1091911277.geojson
+++ b/data/109/191/127/7/1091911277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05305,
-    "geom:area_square_m":655903008.805966,
+    "geom:area_square_m":655903087.550522,
     "geom:bbox":"34.620762,-0.969927,34.920881,-0.704058",
     "geom:latitude":-0.845069,
     "geom:longitude":34.741129,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892597,
-    "wof:geomhash":"ef170cfafee3be62c8074ec062c4e43b",
+    "wof:geomhash":"2870363938944412732027b8f56c629a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1091911277,
-    "wof:lastmodified":1627522275,
+    "wof:lastmodified":1695886745,
     "wof:name":"Gucha",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/131/9/1091911319.geojson
+++ b/data/109/191/131/9/1091911319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095658,
-    "geom:area_square_m":1182748980.250789,
+    "geom:area_square_m":1182748980.250736,
     "geom:bbox":"34.2010604799,-0.859589717138,34.663108279,-0.458030735555",
     "geom:latitude":-0.660709,
     "geom:longitude":34.451475,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892599,
-    "wof:geomhash":"97afdb9564d5703cee8cf9dea62bc520",
+    "wof:geomhash":"9f0df426ea7ecbbd6dd86572e87fe01f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091911319,
-    "wof:lastmodified":1566727039,
+    "wof:lastmodified":1695886182,
     "wof:name":"Homa Bay",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/136/7/1091911367.geojson
+++ b/data/109/191/136/7/1091911367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.058726,
-    "geom:area_square_m":25451645780.606163,
+    "geom:area_square_m":25451645780.606342,
     "geom:bbox":"36.8664338582,-0.0815316139902,39.4629579592,2.1030705438",
     "geom:latitude":1.014149,
     "geom:longitude":38.539842,
@@ -118,9 +118,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892600,
-    "wof:geomhash":"f04ae1640ba420c013559a6a2e544b28",
+    "wof:geomhash":"223dcd772f6baf1434d620ad68e3d2fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1091911367,
-    "wof:lastmodified":1566727039,
+    "wof:lastmodified":1695886182,
     "wof:name":"Isiolo",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/139/9/1091911399.geojson
+++ b/data/109/191/139/9/1091911399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.782354,
-    "geom:area_square_m":22023361589.926044,
+    "geom:area_square_m":22023361589.925316,
     "geom:bbox":"35.9904015395,-3.1828009115,37.942740947,-1.0465786476",
     "geom:latitude":-2.120483,
     "geom:longitude":36.909712,
@@ -106,9 +106,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.KJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892602,
-    "wof:geomhash":"3768bac7b2c0734881de6bdfe1ebf396",
+    "wof:geomhash":"3e46f2dc605fa2a24ee36e4791752968",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1091911399,
-    "wof:lastmodified":1566727039,
+    "wof:lastmodified":1695886183,
     "wof:name":"Kajiado",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/144/5/1091911445.geojson
+++ b/data/109/191/144/5/1091911445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113135,
-    "geom:area_square_m":1398906634.027785,
+    "geom:area_square_m":1398906244.087072,
     "geom:bbox":"34.577707,0.125515,34.975947,0.590185",
     "geom:latitude":0.342513,
     "geom:longitude":34.783256,
@@ -130,9 +130,10 @@
     "wof:concordances":{
         "hasc:id":"KE.WE.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892603,
-    "wof:geomhash":"912ea619f86d812057819f1aa048f9ac",
+    "wof:geomhash":"27ae463375400b58faabaa6657280a27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1091911445,
-    "wof:lastmodified":1636500533,
+    "wof:lastmodified":1695886758,
     "wof:name":"Kakamega",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/149/3/1091911493.geojson
+++ b/data/109/191/149/3/1091911493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117274,
-    "geom:area_square_m":1450059291.392925,
+    "geom:area_square_m":1450059291.392828,
     "geom:bbox":"35.4134689224,0.16976768897,35.7263709794,0.864190256929",
     "geom:latitude":0.489195,
     "geom:longitude":35.572029,
@@ -91,9 +91,10 @@
         "hasc:id":"KE.RV.KY",
         "wd:id":"Q1684196"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892605,
-    "wof:geomhash":"214190dda7164e148b8b5bfba439b3ec",
+    "wof:geomhash":"7e0f43acd951cb7a6716c2ecff16452b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1091911493,
-    "wof:lastmodified":1566727041,
+    "wof:lastmodified":1695886184,
     "wof:name":"Keiyo",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/153/3/1091911533.geojson
+++ b/data/109/191/153/3/1091911533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170318,
-    "geom:area_square_m":2105995487.88165,
+    "geom:area_square_m":2105995916.479697,
     "geom:bbox":"35.008004,-0.499481,35.669391,0.029649",
     "geom:latitude":-0.241517,
     "geom:longitude":35.339228,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892606,
-    "wof:geomhash":"a25c03a996032c7e3aa7aec0b5fc4362",
+    "wof:geomhash":"6e45405c0ae77303a018116e7e1432a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1091911533,
-    "wof:lastmodified":1636500533,
+    "wof:lastmodified":1695886758,
     "wof:name":"Kericho",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/157/1/1091911571.geojson
+++ b/data/109/191/157/1/1091911571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107351,
-    "geom:area_square_m":1327173929.889546,
+    "geom:area_square_m":1327173462.084126,
     "geom:bbox":"36.498681,-1.308086,36.899679,-0.757074",
     "geom:latitude":-1.085849,
     "geom:longitude":36.68823,
@@ -100,9 +100,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CE.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892608,
-    "wof:geomhash":"44d6d494a05cfd409523fff6e39894c6",
+    "wof:geomhash":"4e134514002660d254654f30263340de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1091911571,
-    "wof:lastmodified":1627522275,
+    "wof:lastmodified":1695886745,
     "wof:name":"Kiambu",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/109/191/161/1/1091911611.geojson
+++ b/data/109/191/161/1/1091911611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.390277,
-    "geom:area_square_m":4816521976.758773,
+    "geom:area_square_m":4816522718.987692,
     "geom:bbox":"39.087424,-3.987882,39.96875,-3.211776",
     "geom:latitude":-3.558911,
     "geom:longitude":39.571754,
@@ -136,9 +136,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CO.KF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892610,
-    "wof:geomhash":"f8c9a736ba931a6ebb4f7b1d814d7c0a",
+    "wof:geomhash":"6c1d82a95850d7baa1d7d53e9c65aef9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":1091911611,
-    "wof:lastmodified":1636500531,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kilifi",
     "wof:parent_id":85672943,
     "wof:placetype":"county",

--- a/data/109/191/165/7/1091911657.geojson
+++ b/data/109/191/165/7/1091911657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111119,
-    "geom:area_square_m":1374006139.125291,
+    "geom:area_square_m":1374006139.125231,
     "geom:bbox":"34.412569467,-0.292783913788,35.0137802582,0.0116208245787",
     "geom:latitude":-0.129808,
     "geom:longitude":34.683204,
@@ -191,9 +191,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892611,
-    "wof:geomhash":"74558b248d2868817a641d2359dd79b9",
+    "wof:geomhash":"b9413e35d2425026f340f83531420a9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -203,7 +204,7 @@
         }
     ],
     "wof:id":1091911657,
-    "wof:lastmodified":1566727039,
+    "wof:lastmodified":1695886183,
     "wof:name":"Kisumu",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/168/1/1091911681.geojson
+++ b/data/109/191/168/1/1091911681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.658942,
-    "geom:area_square_m":20501401558.962315,
+    "geom:area_square_m":20501401558.962494,
     "geom:bbox":"37.5937406257,-3.07001153687,39.0604337308,-1.05602256904",
     "geom:latitude":-1.86989,
     "geom:longitude":38.444718,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892613,
-    "wof:geomhash":"0401d008c723df8505f5a3ac5a2091c6",
+    "wof:geomhash":"6a4cfeb56eee0c41f3f27ffceaba14d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1091911681,
-    "wof:lastmodified":1566727036,
+    "wof:lastmodified":1695886181,
     "wof:name":"Kitui",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/171/9/1091911719.geojson
+++ b/data/109/191/171/9/1091911719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18754,
-    "geom:area_square_m":2318965897.146747,
+    "geom:area_square_m":2318965598.649073,
     "geom:bbox":"35.522796,-0.222055,36.216927,0.412919",
     "geom:latitude":0.107758,
     "geom:longitude":35.870927,
@@ -73,9 +73,10 @@
         "hasc:id":"KE.RV.BA",
         "wd:id":"Q1778818"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892614,
-    "wof:geomhash":"1a8430b262c49c67f419ffecc8448f6f",
+    "wof:geomhash":"389acd7cff3f91b15876a5c2a3795168",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1091911719,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886745,
     "wof:name":"Koibatek",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/175/3/1091911753.geojson
+++ b/data/109/191/175/3/1091911753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049017,
-    "geom:area_square_m":605972166.590734,
+    "geom:area_square_m":605972166.590702,
     "geom:bbox":"34.3713821843,-1.38651629996,34.729203161,-1.09555076999",
     "geom:latitude":-1.218079,
     "geom:longitude":34.566289,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892616,
-    "wof:geomhash":"37794744c29cc8bf02971809bb6c6581",
+    "wof:geomhash":"a80fa9ae89da773347f42aa8c596fb65",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091911753,
-    "wof:lastmodified":1566727039,
+    "wof:lastmodified":1695886183,
     "wof:name":"Kuria",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/177/3/1091911773.geojson
+++ b/data/109/191/177/3/1091911773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.68164,
-    "geom:area_square_m":8406494616.137055,
+    "geom:area_square_m":8406493684.680597,
     "geom:bbox":"38.450401,-4.680056,39.643727,-3.564084",
     "geom:latitude":-4.144184,
     "geom:longitude":39.155341,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CO.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892617,
-    "wof:geomhash":"a554fc363c6773f3ab2075fefa8a011d",
+    "wof:geomhash":"132c88d279ff64f715906966fb8b13d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091911773,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886745,
     "wof:name":"Kwale",
     "wof:parent_id":85672943,
     "wof:placetype":"county",

--- a/data/109/191/180/9/1091911809.geojson
+++ b/data/109/191/180/9/1091911809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.769432,
-    "geom:area_square_m":9513936413.043606,
+    "geom:area_square_m":9513936784.402033,
     "geom:bbox":"36.237622,-0.274654,37.397328,0.870991",
     "geom:latitude":0.327531,
     "geom:longitude":36.77272,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.LK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892619,
-    "wof:geomhash":"8729c26698309d3a4dfff84230c79d6d",
+    "wof:geomhash":"5437e9b4f533ed8e4a2b72143e9c4c14",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091911809,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886745,
     "wof:name":"Laikipia",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/182/5/1091911825.geojson
+++ b/data/109/191/182/5/1091911825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.525388,
-    "geom:area_square_m":6492342031.542585,
+    "geom:area_square_m":6492342031.542275,
     "geom:bbox":"40.2145857205,-2.47,41.5572640925,-1.66135537054",
     "geom:latitude":-2.047279,
     "geom:longitude":40.777607,
@@ -160,9 +160,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CO.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892620,
-    "wof:geomhash":"94f26ee8bdd411637366e147863aa108",
+    "wof:geomhash":"ede48820421a709fa7d69eb2c76cb4af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":1091911825,
-    "wof:lastmodified":1566727041,
+    "wof:lastmodified":1695886184,
     "wof:name":"Lamu",
     "wof:parent_id":85672943,
     "wof:placetype":"county",

--- a/data/109/191/184/5/1091911845.geojson
+++ b/data/109/191/184/5/1091911845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054448,
-    "geom:area_square_m":673215648.248731,
+    "geom:area_square_m":673214965.514695,
     "geom:bbox":"34.686335,0.475516,35.156358,0.901625",
     "geom:latitude":0.698358,
     "geom:longitude":34.992359,
@@ -73,9 +73,10 @@
         "hasc:id":"KE.WE.BN",
         "wd:id":"Q1717777"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892622,
-    "wof:geomhash":"bf6739404b30234ec562d9d98c37d7c9",
+    "wof:geomhash":"62e48868b062dd5e56a3f6a634ae2cad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1091911845,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886745,
     "wof:name":"Lugari",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/187/3/1091911873.geojson
+++ b/data/109/191/187/3/1091911873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.506566,
-    "geom:area_square_m":6262152081.541307,
+    "geom:area_square_m":6262152005.811353,
     "geom:bbox":"36.880171,-1.78,37.865442,-0.776188",
     "geom:latitude":-1.288343,
     "geom:longitude":37.407023,
@@ -154,9 +154,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892624,
-    "wof:geomhash":"515e06e43b1659ba7a729a478c26c5b3",
+    "wof:geomhash":"256a7220d6dcb073b5dc61069bf91c11",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1091911873,
-    "wof:lastmodified":1636500532,
+    "wof:lastmodified":1695886758,
     "wof:name":"Machakos",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/187/5/1091911875.geojson
+++ b/data/109/191/187/5/1091911875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.65263,
-    "geom:area_square_m":8063978380.830257,
+    "geom:area_square_m":8063978550.884048,
     "geom:bbox":"37.14518,-2.989342,38.509189,-1.516349",
     "geom:latitude":-2.165767,
     "geom:longitude":37.802346,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892626,
-    "wof:geomhash":"bdef97ab4c2b383a42275ad673424b84",
+    "wof:geomhash":"bfb88f3adf3f906dce22b2c792db08cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091911875,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886745,
     "wof:name":"Makueni",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/187/7/1091911877.geojson
+++ b/data/109/191/187/7/1091911877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.638984,
-    "geom:area_square_m":7890742954.687093,
+    "geom:area_square_m":7890742716.382896,
     "geom:bbox":"39.156438,-3.39125,40.242054,-2.30989",
     "geom:latitude":-2.933772,
     "geom:longitude":39.756977,
@@ -76,9 +76,10 @@
         "hasc:id":"KE.CO.KF",
         "wd:id":"Q1852189"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892628,
-    "wof:geomhash":"a5ac6a96b1d64cdd03ebdc4d9b74bdfa",
+    "wof:geomhash":"9a13c4581bc48f7c5d48b58590a495a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091911877,
-    "wof:lastmodified":1636500532,
+    "wof:lastmodified":1695886758,
     "wof:name":"Malindi",
     "wof:parent_id":85672943,
     "wof:placetype":"county",

--- a/data/109/191/188/1/1091911881.geojson
+++ b/data/109/191/188/1/1091911881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.113481,
-    "geom:area_square_m":26085810243.866531,
+    "geom:area_square_m":26085809900.962418,
     "geom:bbox":"39.78171,2.17291,41.906838,4.285202",
     "geom:latitude":3.438789,
     "geom:longitude":40.736963,
@@ -154,9 +154,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NE.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892629,
-    "wof:geomhash":"da8450c5dd6ad5848bd649b33737cc1f",
+    "wof:geomhash":"12facc9032de285ea1945afd5eced8f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1091911881,
-    "wof:lastmodified":1636500533,
+    "wof:lastmodified":1695886758,
     "wof:name":"Mandera",
     "wof:parent_id":85672969,
     "wof:placetype":"county",

--- a/data/109/191/193/1/1091911931.geojson
+++ b/data/109/191/193/1/1091911931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07029,
-    "geom:area_square_m":869054186.534448,
+    "geom:area_square_m":869054393.265383,
     "geom:bbox":"36.706986,-0.968521,37.265971,-0.665602",
     "geom:latitude":-0.832669,
     "geom:longitude":37.038875,
@@ -90,9 +90,10 @@
         "hasc:id":"KE.CE.MA",
         "wd:id":"Q2311126"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892631,
-    "wof:geomhash":"9478354b99b6b4da22b4f0847dcc3632",
+    "wof:geomhash":"f0572d6f4c6be145aba64f9483adcd49",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091911931,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886746,
     "wof:name":"Maragua",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/109/191/196/5/1091911965.geojson
+++ b/data/109/191/196/5/1091911965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128187,
-    "geom:area_square_m":1584772117.711244,
+    "geom:area_square_m":1584772117.711129,
     "geom:bbox":"35.1577595776,0.850943544442,35.7101983616,1.319848718",
     "geom:latitude":1.084439,
     "geom:longitude":35.508176,
@@ -82,9 +82,10 @@
         "hasc:id":"KE.RV.WP",
         "wd:id":"Q1741465"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892632,
-    "wof:geomhash":"ad0d47e08cc365601d1b7b0bdd7e052f",
+    "wof:geomhash":"60b8e3ae5b78f9bf4a972597b3e619f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1091911965,
-    "wof:lastmodified":1566727039,
+    "wof:lastmodified":1695886183,
     "wof:name":"Marakwet",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/200/7/1091912007.geojson
+++ b/data/109/191/200/7/1091912007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.286271,
-    "geom:area_square_m":65272446439.194389,
+    "geom:area_square_m":65272445327.690598,
     "geom:bbox":"36.013414,1.2755,38.960949,4.459143",
     "geom:latitude":2.964955,
     "geom:longitude":37.410517,
@@ -109,9 +109,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892633,
-    "wof:geomhash":"7bae1a67b29f0d33ed42d6f5d4aac878",
+    "wof:geomhash":"cdd20be86fe14722df67dca55312826c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1091912007,
-    "wof:lastmodified":1636500534,
+    "wof:lastmodified":1695886759,
     "wof:name":"Marsabit",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/205/5/1091912055.geojson
+++ b/data/109/191/205/5/1091912055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169843,
-    "geom:area_square_m":2099996455.867274,
+    "geom:area_square_m":2099996656.051605,
     "geom:bbox":"37.269423,-0.911977,37.935709,-0.341212",
     "geom:latitude":-0.666783,
     "geom:longitude":37.667186,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.EB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892635,
-    "wof:geomhash":"e5d57ec6b170a07fb1a2dca3fe5d7d33",
+    "wof:geomhash":"b05ea5e3e51068a3476ae0084905efcd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091912055,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886746,
     "wof:name":"Mbeere",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/209/7/1091912097.geojson
+++ b/data/109/191/209/7/1091912097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242871,
-    "geom:area_square_m":3003141025.967204,
+    "geom:area_square_m":3003141488.455754,
     "geom:bbox":"37.090828,-0.213838,37.896421,0.331793",
     "geom:latitude":0.019008,
     "geom:longitude":37.512097,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892636,
-    "wof:geomhash":"7bc05e2d79db13d6b708b72721318fd9",
+    "wof:geomhash":"4140be3bf72b01421f27947de0f299f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091912097,
-    "wof:lastmodified":1627522276,
+    "wof:lastmodified":1695886746,
     "wof:name":"Meru Central",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/212/7/1091912127.geojson
+++ b/data/109/191/212/7/1091912127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.320763,
-    "geom:area_square_m":3966227413.619046,
+    "geom:area_square_m":3966226970.759265,
     "geom:bbox":"37.562996,-0.084684,38.416245,0.671637",
     "geom:latitude":0.288644,
     "geom:longitude":37.949341,
@@ -82,9 +82,10 @@
         "hasc:id":"KE.EA.MN",
         "wd:id":"Q5259795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892638,
-    "wof:geomhash":"fd12802f8fdee794d8b9b5bf7420900d",
+    "wof:geomhash":"7dfd224ff836625d2152420ebdc5550c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1091912127,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Meru North",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/216/9/1091912169.geojson
+++ b/data/109/191/216/9/1091912169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087704,
-    "geom:area_square_m":1084459382.358141,
+    "geom:area_square_m":1084459316.401567,
     "geom:bbox":"37.316854,-0.44842,37.891795,-0.149216",
     "geom:latitude":-0.290032,
     "geom:longitude":37.657562,
@@ -85,9 +85,10 @@
         "hasc:id":"KE.EA.MS",
         "wd:id":"Q1894683"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892639,
-    "wof:geomhash":"c8229c52d2a05e207b4ea1bba8270df1",
+    "wof:geomhash":"bab8e8ac1e638284fc30cab5861e0f2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1091912169,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Meru South",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/220/5/1091912205.geojson
+++ b/data/109/191/220/5/1091912205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.206436,
-    "geom:area_square_m":2552276209.629669,
+    "geom:area_square_m":2552276209.629676,
     "geom:bbox":"33.9324379623,-1.18605029549,34.6485487087,-0.648407047812",
     "geom:latitude":-0.937756,
     "geom:longitude":34.32549,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892641,
-    "wof:geomhash":"4759c4e8f63601fe2d37811dc638e5d8",
+    "wof:geomhash":"a3aabecbadf39e398198748db8e57d53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091912205,
-    "wof:lastmodified":1566727037,
+    "wof:lastmodified":1695886182,
     "wof:name":"Migori",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/220/7/1091912207.geojson
+++ b/data/109/191/220/7/1091912207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021741,
-    "geom:area_square_m":268172343.233079,
+    "geom:area_square_m":268172343.23311,
     "geom:bbox":"39.5629970643,-4.15227602331,39.762889862,-3.92034167672",
     "geom:latitude":-4.015233,
     "geom:longitude":39.653721,
@@ -301,9 +301,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CO.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892642,
-    "wof:geomhash":"a28ce15af8ce1760b30e793b1920521b",
+    "wof:geomhash":"ce9385b55c5d92bbb5f5f8280625dcbd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -313,7 +314,7 @@
         }
     ],
     "wof:id":1091912207,
-    "wof:lastmodified":1566727036,
+    "wof:lastmodified":1695886181,
     "wof:name":"Mombasa",
     "wof:parent_id":85672943,
     "wof:placetype":"county",

--- a/data/109/191/222/3/1091912223.geojson
+++ b/data/109/191/222/3/1091912223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.782795,
-    "geom:area_square_m":9664817682.29459,
+    "geom:area_square_m":9664817937.100388,
     "geom:bbox":"38.12863,2.154857,39.347745,3.659439",
     "geom:latitude":3.131123,
     "geom:longitude":38.819339,
@@ -97,9 +97,10 @@
         "hasc:id":"KE.EA.MB",
         "wd:id":"Q2198934"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892644,
-    "wof:geomhash":"bbf4309accbff221f7ceb04d930dd9de",
+    "wof:geomhash":"6872871e960f038f8d0cdd940dd7cb3e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091912223,
-    "wof:lastmodified":1636500534,
+    "wof:lastmodified":1695886759,
     "wof:name":"Moyale",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/226/7/1091912267.geojson
+++ b/data/109/191/226/7/1091912267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076507,
-    "geom:area_square_m":945893617.094594,
+    "geom:area_square_m":945893416.21657,
     "geom:bbox":"34.406537,0.773325,34.798919,1.148015",
     "geom:latitude":0.927961,
     "geom:longitude":34.5973,
@@ -56,9 +56,10 @@
     "wof:concordances":{
         "hasc:id":"KE.WE.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892646,
-    "wof:geomhash":"1ab32213477daa30ba4c5a34a84ec743",
+    "wof:geomhash":"8cf43dcd472cfc19ece8a855e80f47b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -68,7 +69,7 @@
         }
     ],
     "wof:id":1091912267,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Mt Elgon",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/229/1/1091912291.geojson
+++ b/data/109/191/229/1/1091912291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.07599,
-    "geom:area_square_m":939561773.262613,
+    "geom:area_square_m":939561508.062292,
     "geom:bbox":"36.705969,-0.78117,37.261541,-0.56265",
     "geom:latitude":-0.676736,
     "geom:longitude":36.973484,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CE.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892647,
-    "wof:geomhash":"25561ce33331fce7162c9b9a370b14aa",
+    "wof:geomhash":"e218801c8a9644ecdff78176a53d3bb7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091912291,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Muranga",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/109/191/229/3/1091912293.geojson
+++ b/data/109/191/229/3/1091912293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.819817,
-    "geom:area_square_m":10136302167.657398,
+    "geom:area_square_m":10136302300.696041,
     "geom:bbox":"37.802673,-1.200565,38.972699,-0.049526",
     "geom:latitude":-0.708652,
     "geom:longitude":38.331915,
@@ -116,9 +116,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892649,
-    "wof:geomhash":"d4f9f21b9ec939eacca46dedd48c1dec",
+    "wof:geomhash":"23f37c8a43b9ff8720f02251cd47a423",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1091912293,
-    "wof:lastmodified":1636500531,
+    "wof:lastmodified":1695886757,
     "wof:name":"Mwingi",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/236/5/1091912365.geojson
+++ b/data/109/191/236/5/1091912365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.606088,
-    "geom:area_square_m":7494049416.734861,
+    "geom:area_square_m":7494049416.735525,
     "geom:bbox":"35.4181082678,-1.15010892578,36.6000492871,0.240968980638",
     "geom:latitude":-0.462609,
     "geom:longitude":36.080438,
@@ -190,9 +190,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.NK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892652,
-    "wof:geomhash":"2d6a80eb9321f793d1c85d6922b2e153",
+    "wof:geomhash":"e342041a6a47826bad08639e1cbeb596",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1091912365,
-    "wof:lastmodified":1566727040,
+    "wof:lastmodified":1695886183,
     "wof:name":"Nakuru",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/240/3/1091912403.geojson
+++ b/data/109/191/240/3/1091912403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.234901,
-    "geom:area_square_m":2904565037.472619,
+    "geom:area_square_m":2904564833.031348,
     "geom:bbox":"34.740662,-0.105987,35.438468,0.563662",
     "geom:latitude":0.188556,
     "geom:longitude":35.114353,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892653,
-    "wof:geomhash":"e6ca726c4786e72fc7019588068f499f",
+    "wof:geomhash":"30ff36b0243c0d31786f9cdeb6a76c4a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1091912403,
-    "wof:lastmodified":1636500533,
+    "wof:lastmodified":1695886758,
     "wof:name":"Nandi",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/245/1/1091912451.geojson
+++ b/data/109/191/245/1/1091912451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.223831,
-    "geom:area_square_m":15128903348.393574,
+    "geom:area_square_m":15128903348.393635,
     "geom:bbox":"34.9896947305,-2.09953552717,36.3507270614,-0.452113441449",
     "geom:latitude":-1.270518,
     "geom:longitude":35.704569,
@@ -112,9 +112,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892655,
-    "wof:geomhash":"d245d107aed1b9a8c5dd808a497a7ce5",
+    "wof:geomhash":"1fb30ff9bf50dbbfc420879cdcaf2b96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1091912451,
-    "wof:lastmodified":1566727037,
+    "wof:lastmodified":1695886182,
     "wof:name":"Narok",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/249/3/1091912493.geojson
+++ b/data/109/191/249/3/1091912493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0728,
-    "geom:area_square_m":900133546.84772,
+    "geom:area_square_m":900133546.847806,
     "geom:bbox":"34.7939621783,-0.878412622434,35.0922865548,-0.405069794908",
     "geom:latitude":-0.637753,
     "geom:longitude":34.967874,
@@ -85,9 +85,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.NM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892656,
-    "wof:geomhash":"56787c8cf884252817393af1466b1ab8",
+    "wof:geomhash":"3c98cf9c97963c119ca5db269d02bead",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1091912493,
-    "wof:lastmodified":1566727040,
+    "wof:lastmodified":1695886183,
     "wof:name":"Nyamira",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/251/1/1091912511.geojson
+++ b/data/109/191/251/1/1091912511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104184,
-    "geom:area_square_m":1288248967.852934,
+    "geom:area_square_m":1288248967.852778,
     "geom:bbox":"34.6706289365,-0.410598204931,35.3440204468,-0.00580134083841",
     "geom:latitude":-0.203733,
     "geom:longitude":35.009715,
@@ -73,9 +73,10 @@
         "hasc:id":"KE.NY.KU",
         "wd:id":"Q1779500"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892658,
-    "wof:geomhash":"eaf15db76baa9ba8820f7715ce68acab",
+    "wof:geomhash":"6acfd1c3a6f217895d5d9c853ca86268",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1091912511,
-    "wof:lastmodified":1566727038,
+    "wof:lastmodified":1695886182,
     "wof:name":"Nyando",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/254/1/1091912541.geojson
+++ b/data/109/191/254/1/1091912541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.271646,
-    "geom:area_square_m":3358881923.259597,
+    "geom:area_square_m":3358881923.259669,
     "geom:bbox":"36.6075076122,-0.642487868295,37.3111364502,0.00963164215139",
     "geom:latitude":-0.339389,
     "geom:longitude":36.956235,
@@ -160,9 +160,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CE.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892659,
-    "wof:geomhash":"b230f8d1811c791e8056361ab43bd3f0",
+    "wof:geomhash":"29f657cd4f0c5801514febf16e221259",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":1091912541,
-    "wof:lastmodified":1566727041,
+    "wof:lastmodified":1695886184,
     "wof:name":"Nyeri",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/109/191/258/1/1091912581.geojson
+++ b/data/109/191/258/1/1091912581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.718376,
-    "geom:area_square_m":21241812935.573547,
+    "geom:area_square_m":21241812935.574238,
     "geom:bbox":"36.2944458532,0.571711831074,38.0732468092,2.51964246861",
     "geom:latitude":1.326791,
     "geom:longitude":37.11726,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892661,
-    "wof:geomhash":"4c2e9a8287cef9f89311ea8bb4e097a6",
+    "wof:geomhash":"8d786c03dd398a7c93fa4ab92c8ffffa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091912581,
-    "wof:lastmodified":1566727038,
+    "wof:lastmodified":1695886182,
     "wof:name":"Samburu",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/258/3/1091912583.geojson
+++ b/data/109/191/258/3/1091912583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12238,
-    "geom:area_square_m":1513250159.371988,
+    "geom:area_square_m":1513250159.371931,
     "geom:bbox":"34.0523112965,-0.0746359870924,34.5640842503,0.316003790525",
     "geom:latitude":0.114263,
     "geom:longitude":34.307746,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892662,
-    "wof:geomhash":"f497209dcc0bac08ec2b49a64d01c836",
+    "wof:geomhash":"cb7f56c67b7c4d67c389a81d30fe70a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091912583,
-    "wof:lastmodified":1566727038,
+    "wof:lastmodified":1695886182,
     "wof:name":"Siaya",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/258/5/1091912585.geojson
+++ b/data/109/191/258/5/1091912585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198734,
-    "geom:area_square_m":2457272523.219501,
+    "geom:area_square_m":2457271755.530729,
     "geom:bbox":"33.925475,-0.841844,34.463004,-0.279606",
     "geom:latitude":-0.542984,
     "geom:longitude":34.133762,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NY.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892664,
-    "wof:geomhash":"e40dc48753a2a16f422055c673de18e0",
+    "wof:geomhash":"6300ffc062c23226c493b032e5c3615b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091912585,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Suba",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/109/191/258/7/1091912587.geojson
+++ b/data/109/191/258/7/1091912587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.096477,
-    "geom:area_square_m":38270830077.125114,
+    "geom:area_square_m":38270830395.193855,
     "geom:bbox":"38.425798,-3.06715,40.721545,-0.015533",
     "geom:latitude":-1.552352,
     "geom:longitude":39.416152,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"KE.CO.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892665,
-    "wof:geomhash":"fe90c7b584bd4116e83141d3e64b0f2c",
+    "wof:geomhash":"0c3d3cf7a15a9ce7ae1190ad4973efa5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091912587,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Tana River",
     "wof:parent_id":85672943,
     "wof:placetype":"county",

--- a/data/109/191/261/3/1091912613.geojson
+++ b/data/109/191/261/3/1091912613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045076,
-    "geom:area_square_m":557336789.86143,
+    "geom:area_square_m":557336708.716533,
     "geom:bbox":"34.103645,0.450815,34.443217,0.780251",
     "geom:latitude":0.602379,
     "geom:longitude":34.274766,
@@ -79,9 +79,10 @@
         "hasc:id":"KE.WE.BS",
         "wd:id":"Q1577530"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892667,
-    "wof:geomhash":"37915e33ee9e733fdaecab8b730e4411",
+    "wof:geomhash":"d0f0c4ea212963ecb1a13152fb88ec2a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091912613,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Teso",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/263/9/1091912639.geojson
+++ b/data/109/191/263/9/1091912639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126092,
-    "geom:area_square_m":1559141701.256171,
+    "geom:area_square_m":1559141785.132778,
     "geom:bbox":"37.796273,-0.425407,38.305442,0.069247",
     "geom:latitude":-0.135363,
     "geom:longitude":38.023025,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"KE.EA.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892669,
-    "wof:geomhash":"4b7405ab48a5a0487cb5c2bee3ec912d",
+    "wof:geomhash":"04fd4354f3b3602148e75d191243c8b0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1091912639,
-    "wof:lastmodified":1627522277,
+    "wof:lastmodified":1695886746,
     "wof:name":"Tharaka",
     "wof:parent_id":85672959,
     "wof:placetype":"county",

--- a/data/109/191/268/1/1091912681.geojson
+++ b/data/109/191/268/1/1091912681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158909,
-    "geom:area_square_m":1964629555.099447,
+    "geom:area_square_m":1964629523.441259,
     "geom:bbox":"36.654638,-1.253635,37.419697,-0.697654",
     "geom:latitude":-1.007492,
     "geom:longitude":37.017672,
@@ -79,9 +79,10 @@
         "hasc:id":"KE.CE.KB",
         "wd:id":"Q2575085"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892670,
-    "wof:geomhash":"a6dea29ea48e4f99cdf849bd7cbb88bc",
+    "wof:geomhash":"846ae543f1b9cb3c611f8365c9ff885d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091912681,
-    "wof:lastmodified":1636500532,
+    "wof:lastmodified":1695886758,
     "wof:name":"Thika",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/109/191/271/7/1091912717.geojson
+++ b/data/109/191/271/7/1091912717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.233194,
-    "geom:area_square_m":2882883469.564438,
+    "geom:area_square_m":2882883561.574157,
     "geom:bbox":"34.588088,-1.549473,35.242985,-0.884578",
     "geom:latitude":-1.159987,
     "geom:longitude":34.899852,
@@ -76,9 +76,10 @@
         "hasc:id":"KE.RV.NR",
         "wd:id":"Q1754960"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892672,
-    "wof:geomhash":"9074ba19bdccd89059a836ab8d128a2a",
+    "wof:geomhash":"9a737523ff0d708fcfcbb0f2b468552e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091912717,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886747,
     "wof:name":"Trans Mara",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/275/7/1091912757.geojson
+++ b/data/109/191/275/7/1091912757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.201901,
-    "geom:area_square_m":2496121672.864428,
+    "geom:area_square_m":2496122166.724576,
     "geom:bbox":"34.581985,0.809179,35.361624,1.280439",
     "geom:latitude":1.052413,
     "geom:longitude":34.958584,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892673,
-    "wof:geomhash":"bad1b02cb252e1c5a33b704b88a8258d",
+    "wof:geomhash":"4bbef0e0427116ba363977fcdeb2be24",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091912757,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886747,
     "wof:name":"Trans Nzoia",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/279/5/1091912795.geojson
+++ b/data/109/191/279/5/1091912795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.31589,
-    "geom:area_square_m":65617143991.901283,
+    "geom:area_square_m":65617143991.903824,
     "geom:bbox":"33.992061,0.920855741536,36.7274118261,5.033421",
     "geom:latitude":3.254148,
     "geom:longitude":35.453029,
@@ -115,9 +115,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.TU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892675,
-    "wof:geomhash":"7c37aa04919cdc03e2bfca769f6bb2ce",
+    "wof:geomhash":"454628a7208164f4d7c0cfe12e2e676d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1091912795,
-    "wof:lastmodified":1566727040,
+    "wof:lastmodified":1695886184,
     "wof:name":"Turkana",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/283/7/1091912837.geojson
+++ b/data/109/191/283/7/1091912837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.271201,
-    "geom:area_square_m":3353280426.965643,
+    "geom:area_square_m":3353281145.285178,
     "geom:bbox":"34.855296,0.008604,35.591194,0.951012",
     "geom:latitude":0.536243,
     "geom:longitude":35.320844,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.UG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892677,
-    "wof:geomhash":"7587d1e63294dedbafe25f4d545de420",
+    "wof:geomhash":"7f0e7a27cf219422c39a5683f39640c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091912837,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886747,
     "wof:name":"Uasin Gishu",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/109/191/285/1/1091912851.geojson
+++ b/data/109/191/285/1/1091912851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04522,
-    "geom:area_square_m":559148473.680393,
+    "geom:area_square_m":559148862.749766,
     "geom:bbox":"34.536052,-0.037777,34.926007,0.206348",
     "geom:latitude":0.079637,
     "geom:longitude":34.722086,
@@ -97,9 +97,10 @@
     "wof:concordances":{
         "hasc:id":"KE.WE.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892678,
-    "wof:geomhash":"d16b553fecaced4facc8eb9c3349a88b",
+    "wof:geomhash":"d7c711f36ed583b4014fbb63b74f6b65",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091912851,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886747,
     "wof:name":"Vihiga",
     "wof:parent_id":85672967,
     "wof:placetype":"county",

--- a/data/109/191/287/9/1091912879.geojson
+++ b/data/109/191/287/9/1091912879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.616795,
-    "geom:area_square_m":57053382510.328049,
+    "geom:area_square_m":57053382797.258347,
     "geom:bbox":"38.889711,0.180214,40.994374,3.690088",
     "geom:latitude":1.811359,
     "geom:longitude":40.034755,
@@ -175,9 +175,10 @@
     "wof:concordances":{
         "hasc:id":"KE.NE.WJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892680,
-    "wof:geomhash":"6ab35dd915618f113bffc358c4b2b496",
+    "wof:geomhash":"d53f2f5c74296df6021aa2674fd24749",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1091912879,
-    "wof:lastmodified":1636500532,
+    "wof:lastmodified":1695886758,
     "wof:name":"Wajir",
     "wof:parent_id":85672969,
     "wof:placetype":"county",

--- a/data/109/191/290/7/1091912907.geojson
+++ b/data/109/191/290/7/1091912907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.736431,
-    "geom:area_square_m":9101804223.502258,
+    "geom:area_square_m":9101804500.341082,
     "geom:bbox":"34.771691,1.120161,35.788821,2.666481",
     "geom:latitude":1.725039,
     "geom:longitude":35.245421,
@@ -55,9 +55,10 @@
     "wof:concordances":{
         "hasc:id":"KE.RV.WP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1473892681,
-    "wof:geomhash":"d1c494a3f279caead6400386e0d5c562",
+    "wof:geomhash":"953f1fd016413dff313c310192825780",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -67,7 +68,7 @@
         }
     ],
     "wof:id":1091912907,
-    "wof:lastmodified":1627522278,
+    "wof:lastmodified":1695886747,
     "wof:name":"West Pokot",
     "wof:parent_id":85672963,
     "wof:placetype":"county",

--- a/data/856/323/29/85632329.geojson
+++ b/data/856/323/29/85632329.geojson
@@ -1197,6 +1197,7 @@
         "hasc:id":"KE",
         "icao:code":"5Y",
         "ioc:id":"KEN",
+        "iso:code":"KE",
         "itu:id":"KEN",
         "loc:id":"n80061011",
         "m49:code":"404",
@@ -1211,6 +1212,7 @@
         "wk:page":"Kenya",
         "wmo:id":"KN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KE",
     "wof:country_alpha3":"KEN",
     "wof:geom_alt":[
@@ -1236,7 +1238,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694639632,
+    "wof:lastmodified":1695881294,
     "wof:name":"Kenya",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/729/43/85672943.geojson
+++ b/data/856/729/43/85672943.geojson
@@ -414,9 +414,11 @@
         "gn:id":199247,
         "gp:id":2345938,
         "hasc:id":"KE.CO",
+        "iso:code_historic":"KE-300",
         "qs_pg:id":673247,
         "wd:id":"Q93352"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:country":"KE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -438,7 +440,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884286,
     "wof:name":"Coast",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/47/85672947.geojson
+++ b/data/856/729/47/85672947.geojson
@@ -258,10 +258,12 @@
         "gn:id":400742,
         "gp:id":2345937,
         "hasc:id":"KE.CE",
+        "iso:code_historic":"KE-200",
         "qs_pg:id":906484,
         "wd:id":"Q318666",
         "wk:page":"Central Province (Kenya)"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:country":"KE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -283,7 +285,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493258,
+    "wof:lastmodified":1695884870,
     "wof:name":"Central",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/51/85672951.geojson
+++ b/data/856/729/51/85672951.geojson
@@ -255,10 +255,12 @@
         "gn:id":184742,
         "gp:id":2345940,
         "hasc:id":"KE.NA",
+        "iso:code_historic":"KE-110",
         "qs_pg:id":1131390,
         "wd:id":"Q3335223",
         "wk:page":"Nairobi County"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:coterminous":[
         421174401
     ],
@@ -283,7 +285,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884360,
     "wof:name":"Nairobi",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/55/85672955.geojson
+++ b/data/856/729/55/85672955.geojson
@@ -270,10 +270,12 @@
         "gn:id":182763,
         "gp:id":2345942,
         "hasc:id":"KE.NY",
+        "iso:code_historic":"KE-600",
         "qs_pg:id":427269,
         "wd:id":"Q38589",
         "wk:page":"Nyanza Province"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:country":"KE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -295,7 +297,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493258,
+    "wof:lastmodified":1695884870,
     "wof:name":"Nyanza",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/59/85672959.geojson
+++ b/data/856/729/59/85672959.geojson
@@ -263,10 +263,12 @@
         "gn:id":400741,
         "gp:id":2345939,
         "hasc:id":"KE.EA",
+        "iso:code_historic":"KE-400",
         "qs_pg:id":556404,
         "wd:id":"Q328493",
         "wk:page":"Eastern Province (Kenya)"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:country":"KE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -288,7 +290,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493257,
+    "wof:lastmodified":1695884869,
     "wof:name":"Eastern",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/63/85672963.geojson
+++ b/data/856/729/63/85672963.geojson
@@ -294,10 +294,12 @@
         "gn:id":400744,
         "gp:id":2345943,
         "hasc:id":"KE.RV",
+        "iso:code_historic":"KE-700",
         "qs_pg:id":673286,
         "wd:id":"Q38587",
         "wk:page":"Rift Valley Province"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:country":"KE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -319,7 +321,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493130,
+    "wof:lastmodified":1695884360,
     "wof:name":"Rift Valley",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/67/85672967.geojson
+++ b/data/856/729/67/85672967.geojson
@@ -258,10 +258,12 @@
         "gn:id":400743,
         "gp:id":2345944,
         "hasc:id":"KE.WE",
+        "iso:code_historic":"KE-800",
         "qs_pg:id":221177,
         "wd:id":"Q38585",
         "wk:page":"Western Province (Kenya)"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:country":"KE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -283,7 +285,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493258,
+    "wof:lastmodified":1695884870,
     "wof:name":"Western",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/856/729/69/85672969.geojson
+++ b/data/856/729/69/85672969.geojson
@@ -220,10 +220,12 @@
         "gn:id":400745,
         "gp:id":2345941,
         "hasc:id":"KE.NE",
+        "iso:code_historic":"KE-500",
         "qs_pg:id":1114942,
         "wd:id":"Q390213",
         "wk:page":"North Eastern Province (Kenya)"
     },
+    "wof:concordances_official":"iso:code_historic",
     "wof:country":"KE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -245,7 +247,7 @@
         "eng",
         "swa"
     ],
-    "wof:lastmodified":1694493258,
+    "wof:lastmodified":1695884870,
     "wof:name":"North-Eastern",
     "wof:parent_id":85632329,
     "wof:placetype":"region",

--- a/data/890/427/529/890427529.geojson
+++ b/data/890/427/529/890427529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107392,
-    "geom:area_square_m":1327893199.799851,
+    "geom:area_square_m":1327893199.799908,
     "geom:bbox":"34.3911461172,-0.602040800224,35.028944274,-0.236218631583",
     "geom:latitude":-0.401464,
     "geom:longitude":34.665511,
@@ -93,12 +93,13 @@
         "wd:id":"Q2125323",
         "wk:page":"Rachuonyo District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1469051700,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"915ab44dd5b7d6ca2b68473d5d095a2a",
+    "wof:geomhash":"edc18673e54c1297bcff1019971b6cc5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":890427529,
-    "wof:lastmodified":1582344730,
+    "wof:lastmodified":1695886782,
     "wof:name":"Rachuonyo",
     "wof:parent_id":85672955,
     "wof:placetype":"county",

--- a/data/890/431/357/890431357.geojson
+++ b/data/890/431/357/890431357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119169,
-    "geom:area_square_m":1473481234.09023,
+    "geom:area_square_m":1473480599.502553,
     "geom:bbox":"37.148298,-0.783795,37.488235,-0.152541",
     "geom:latitude":-0.523409,
     "geom:longitude":37.319141,
@@ -144,12 +144,13 @@
         "wd:id":"Q2230311",
         "wk:page":"Kirinyaga County"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1469051887,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"485273e20f0cf3e79704ef8b94b6ad4f",
+    "wof:geomhash":"28c6ae8a0fcab1b730ac75d057ebd621",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":890431357,
-    "wof:lastmodified":1690938072,
+    "wof:lastmodified":1695886745,
     "wof:name":"Kirinyaga",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/890/437/763/890437763.geojson
+++ b/data/890/437/763/890437763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266204,
-    "geom:area_square_m":3291579639.581911,
+    "geom:area_square_m":3291579964.84779,
     "geom:bbox":"36.20155,-0.919509,36.730909,0.135426",
     "geom:latitude":-0.31886,
     "geom:longitude":36.482583,
@@ -138,12 +138,13 @@
         "wd:id":"Q1714352",
         "wk:page":"Nyandarua County"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1469052165,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a119d882cdcfeb253dece2fd765ab082",
+    "wof:geomhash":"408c9ccd78ef7d98ac8560ecd1559edf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":890437763,
-    "wof:lastmodified":1690938071,
+    "wof:lastmodified":1695886746,
     "wof:name":"Nyandarua",
     "wof:parent_id":85672947,
     "wof:placetype":"county",

--- a/data/890/442/857/890442857.geojson
+++ b/data/890/442/857/890442857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.398128,
-    "geom:area_square_m":17256824360.43359,
+    "geom:area_square_m":17256824137.849442,
     "geom:bbox":"37.585272,-4.142766,39.22,-2.696511",
     "geom:latitude":-3.433973,
     "geom:longitude":38.418129,
@@ -141,12 +141,13 @@
         "wd:id":"Q7193788",
         "wk:page":"Taita-Taveta County"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"KE",
     "wof:created":1469052383,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d319d0eef50e0e23d00dec6bd2ee0da5",
+    "wof:geomhash":"7db1aa6c7c15f28b28f7a79101c6e517",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":890442857,
-    "wof:lastmodified":1690938074,
+    "wof:lastmodified":1695886782,
     "wof:name":"Taita Taveta",
     "wof:parent_id":85672943,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.